### PR TITLE
:sparkles: empty incidents list

### DIFF
--- a/app/src/main/java/io/capibaras/abcall/ui/views/IncidentsScreen.kt
+++ b/app/src/main/java/io/capibaras/abcall/ui/views/IncidentsScreen.kt
@@ -1,12 +1,20 @@
 package io.capibaras.abcall.ui.views
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.capibaras.abcall.R
 import io.capibaras.abcall.ui.components.IncidentCard
 import io.capibaras.abcall.ui.components.IncidentStatus
 import io.capibaras.abcall.ui.viewmodels.IncidentViewModel
@@ -24,20 +32,32 @@ fun IncidentsScreen(
         isRefreshing = viewModel.isRefreshing,
         onRefresh = { viewModel.onRefresh() },
     ) {
-        LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(24.dp),
-        ) {
-            items(viewModel.incidents.size) { index ->
-                val incident = viewModel.incidents[index]
-                IncidentCard(
-                    title = incident.name,
-                    status = IncidentStatus.fromString(incident.history.last().action),
-                    escalatedDate = incident.escalatedDate,
-                    filedDate = incident.filedDate,
-                    closedDate = incident.closedDate,
-                    recentlyUpdated = incident.recentlyUpdated,
-                    onClick = {}
+        if (viewModel.incidents.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.empty_incidents_list),
+                    fontSize = 18.sp
                 )
+            }
+        } else {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                items(viewModel.incidents.size) { index ->
+                    val incident = viewModel.incidents[index]
+                    IncidentCard(
+                        title = incident.name,
+                        status = IncidentStatus.fromString(incident.history.last().action),
+                        escalatedDate = incident.escalatedDate,
+                        filedDate = incident.filedDate,
+                        closedDate = incident.closedDate,
+                        recentlyUpdated = incident.recentlyUpdated,
+                        onClick = {}
+                    )
+                }
             }
         }
     }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -50,4 +50,5 @@
     <string name="error_server">Estamos experimentando problemas técnicos. Por favor, inténtalo de nuevo más tarde.</string>
     <string name="status">Estado</string>
     <string name="recently_updated">Actualizado recientemente</string>
+    <string name="empty_incidents_list">No tienes peticiones creadas</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -50,5 +50,6 @@
     <string name="error_server">Estamos enfrentando problemas técnicos. Por favor, tente novamente mais tarde.</string>
     <string name="status">Status</string>
     <string name="recently_updated">Atualizado recentemente</string>
+    <string name="empty_incidents_list">No há petições criadas</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,5 @@
     <string name="error_server">Estamos experimentando problemas técnicos. Por favor, inténtalo de nuevo más tarde.</string>
     <string name="status">Estado</string>
     <string name="recently_updated">Actualizado recientemente</string>
+    <string name="empty_incidents_list">No tienes peticiones creadas</string>
 </resources>


### PR DESCRIPTION
![WhatsApp Image 2024-10-26 at 1 00 29 PM](https://github.com/user-attachments/assets/004b85da-47f9-4289-992f-08e9f91a0539)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user feedback on the Incidents Screen by displaying a message when no incidents are available.
	- Added localization support for the message indicating no incidents in Spanish and Portuguese.

- **Bug Fixes**
	- Improved layout logic for better user experience when the incidents list is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->